### PR TITLE
Issue 22: ./build deps fails on ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Install steps:
 
     This will create a local `lib/` directory that contains all Lua scripts that the **nginx-jwt** depends on.
 
+    **NOTE**: This command should work on Mac OS as well as Ubuntu.
+
 1. Deploy the [`nginx-jwt.lua`](nginx-jwt.lua) script as well as the local `lib/` directory (generated in the previous step) to one directory on your Nginx server.
 1. Specify this directory's path using ngx_lua's [lua_package_path](https://github.com/openresty/lua-nginx-module#lua_package_path) directive:  
     ```lua

--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o pipefail
 set -e
@@ -28,7 +28,7 @@ fi
 commands=(run tests deps)
 if [[ ${commands[*]} =~ "$command" ]]; then
     # build Lua script dependencies
-    sh scripts/build_deps.sh
+    bash scripts/build_deps.sh
 fi
 
 if [[ "$command" == "run" ]]; then

--- a/scripts/build_deps.sh
+++ b/scripts/build_deps.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o pipefail
 set -e


### PR DESCRIPTION
Closes #22

This is the minimum set of changes to get `./build deps` to work on Ubuntu.  While a great idea, it's a larger scoped effort to get all of the build scripts to run on Ubuntu.  A good addition to the roadmap.
