### PR TITLE
Bump test timeout

### DIFF
--- a/test/test_integration.js
+++ b/test/test_integration.js
@@ -35,7 +35,7 @@ function stopProxyContainer (name, done) {
 }
 
 describe('proxy', function () {
-    this.timeout(4000);
+    this.timeout(15000);
 
     before(function (done) {
         console.log('    > Building and starting backend container');


### PR DESCRIPTION
Maybe docker became too slow, but on top rMBP it never works within 4s.
