### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,32 @@ If you need to simply stop/delete all running Docker containers and remove their
 ./build clean
 ```
 
+### Updating dependencies
+
+It's always nice to keep dependencies up to date. This library (and the tools used to test it) has three sources of dependencies that should be maintained: Lua dependencies, test script Node.js dependencies, and updates to the proxy base Docker image.
+
+#### Lua dependencies
+
+These are the Lua scripts that [this library](nginx-jwt.lua) uses.  They are maintained in the [`build_deps.sh`](scripts/build_deps.sh) bash script.
+
+Since these dependencies don't have any built-in versioning (like npm), we download a specific GitHub commit instead. We also check that a previously downloaded script is current by examining its SHA-1 digest hash. All this is done via the included  `load_dependency` bash function.
+
+If a Lua dependency needs to be updated, find its associated `load_dependency` function call and update its GitHub `commit` and `sha1` parameter values. You can generate the required SHA-1 digest of a new script file using this command:
+
+```bash
+openssh sha1 NEW_SCRIPT
+```
+
+To add a new dependency simply add a new `load_dependency` command to the script.
+
+#### Test script Node.js dependencies
+
+All Node.js dependencies (npm packages) for tests are maintained in this [`package.json`](test/package.json) file and should be updated as needed using the `npm` command.
+
+#### Proxy base Docker image
+
+The proxy base Docker image may need to be updated periodically, usually to just rev the version of OpenResty that its using. This can be done by modifying the image's [`Dockerfile`](hosts/proxy/Dockerfile). Any change to this file will automatically result in new image builds when the `build` script is run.
+
 ## Issue Reporting
 
 If you have found a bug or if you have a feature request, please report them at this repository issues section. Please do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://auth0.com/whitehat) details the procedure for disclosing security issues.

--- a/hosts/proxy/Dockerfile
+++ b/hosts/proxy/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     libreadline-dev libncurses5-dev libpcre3-dev libssl-dev \
  && rm -rf /var/lib/apt/lists/*
 
-ENV OPENRESTY_VERSION 1.7.7.1
+ENV OPENRESTY_VERSION 1.9.3.1
 ENV OPENRESTY_PREFIX /opt/openresty
 ENV NGINX_PREFIX /opt/openresty/nginx
 ENV VAR_PREFIX /var/nginx

--- a/scripts/build_deps.sh
+++ b/scripts/build_deps.sh
@@ -14,7 +14,7 @@ load_dependency () {
     local commit="$4"
     local required_sha1="$5"
 
-    local actual_sha1=$(cat $target | openssl sha1)
+    local actual_sha1=$(cat $target | openssl sha1 | sed 's/^.* //')
 
     if [ -e "$target" ] && [ "$required_sha1" == "$actual_sha1" ]; then
         echo -e "Dependency $target (with SHA-1 digest $required_sha1) already downloaded."

--- a/scripts/build_deps.sh
+++ b/scripts/build_deps.sh
@@ -12,14 +12,18 @@ load_dependency () {
     local user="$2"
     local repo="$3"
     local commit="$4"
+    local sha1="$5"
 
-    if [ -e "$target" ]; then
-        echo -e "Dependency $target already downloaded."
+    local expected_sha1_response="SHA1($target)= $sha1"
+    local actual_sha1_response=$(openssl sha1 $target)
+
+    if [ -e "$target" ] && [ "$expected_sha1_response" == "$actual_sha1_response" ]; then
+        echo -e "Dependency $target (with SHA-1 digest $sha1) already downloaded."
     else
         curl https://codeload.github.com/$user/$repo/tar.gz/$commit | tar -xz --strip 1 $repo-$commit/lib
     fi
 }
 
-load_dependency "lib/resty/jwt.lua" "SkyLothar" "lua-resty-jwt" "b7976481061239ae2027e02be552b900bf25321c"
-load_dependency "lib/resty/hmac.lua" "jkeys089" "lua-resty-hmac" "67bff3fd6b7ce4f898b4c3deec7a1f6050ff9fc9"
-load_dependency "lib/basexx.lua" "aiq" "basexx" "514f46ceb9a8a867135856abf60aaacfd921d9b9"
+load_dependency "lib/resty/jwt.lua" "SkyLothar" "lua-resty-jwt" "b7976481061239ae2027e02be552b900bf25321c" "3fbc737d2a1defcdf372cab5f854182afbcede6e"
+load_dependency "lib/resty/hmac.lua" "jkeys089" "lua-resty-hmac" "67bff3fd6b7ce4f898b4c3deec7a1f6050ff9fc9" "44dffa232bdf20e9cf13fb37c23df089e4ae1ee2"
+load_dependency "lib/basexx.lua" "aiq" "basexx" "514f46ceb9a8a867135856abf60aaacfd921d9b9" "da8efedf0d96a79a041eddfe45a6438ea4edf58b"

--- a/scripts/build_deps.sh
+++ b/scripts/build_deps.sh
@@ -12,13 +12,12 @@ load_dependency () {
     local user="$2"
     local repo="$3"
     local commit="$4"
-    local sha1="$5"
+    local required_sha1="$5"
 
-    local expected_sha1_response="SHA1($target)= $sha1"
-    local actual_sha1_response=$(openssl sha1 $target)
+    local actual_sha1=$(cat $target | openssl sha1)
 
-    if [ -e "$target" ] && [ "$expected_sha1_response" == "$actual_sha1_response" ]; then
-        echo -e "Dependency $target (with SHA-1 digest $sha1) already downloaded."
+    if [ -e "$target" ] && [ "$required_sha1" == "$actual_sha1" ]; then
+        echo -e "Dependency $target (with SHA-1 digest $required_sha1) already downloaded."
     else
         curl https://codeload.github.com/$user/$repo/tar.gz/$commit | tar -xz --strip 1 $repo-$commit/lib
     fi

--- a/scripts/build_deps.sh
+++ b/scripts/build_deps.sh
@@ -20,6 +20,6 @@ load_dependency () {
     fi
 }
 
-load_dependency "lib/resty/jwt.lua" "SkyLothar" "lua-resty-jwt" "586a507f9e57555bdd7a7bc152303c91b4a04527"
+load_dependency "lib/resty/jwt.lua" "SkyLothar" "lua-resty-jwt" "b7976481061239ae2027e02be552b900bf25321c"
 load_dependency "lib/resty/hmac.lua" "jkeys089" "lua-resty-hmac" "67bff3fd6b7ce4f898b4c3deec7a1f6050ff9fc9"
-load_dependency "lib/basexx.lua" "aiq" "basexx" "c91cf5438385d9f84f53d3ef27f855c52ec2ed76"
+load_dependency "lib/basexx.lua" "aiq" "basexx" "514f46ceb9a8a867135856abf60aaacfd921d9b9"

--- a/scripts/build_proxy_base_image.sh
+++ b/scripts/build_proxy_base_image.sh
@@ -7,7 +7,7 @@ script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 . $script_dir/common.sh
 
 # use sha-1 digest of base image Dockerfle as its Docker image tag, so we build a new base image whenever it changes
-dockerfile_sha1=$(cat $proxy_base_dir/Dockerfile | openssl sha1)
+dockerfile_sha1=$(cat $proxy_base_dir/Dockerfile | openssl sha1 | sed 's/^.* //')
 echo -e "${cyan}Required Dockerfile SHA1:${no_color} $dockerfile_sha1"
 
 echo -e "${cyan}Building base proxy image, if necessary...${no_color}"

--- a/scripts/build_proxy_base_image.sh
+++ b/scripts/build_proxy_base_image.sh
@@ -6,11 +6,16 @@ set -e
 script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 . $script_dir/common.sh
 
-echo -e "${cyan}Building base proxy image, if necessary...${NC}"
-image_exists=$(docker images | grep "proxy-base-image") || true
+# use sha-1 digest of base image Dockerfle as its Docker image tag, so we build a new base image whenever it changes
+dockerfile_sha1=$(cat $proxy_base_dir/Dockerfile | openssl sha1)
+echo -e "${cyan}Required Dockerfile SHA1:${no_color} $dockerfile_sha1"
+
+echo -e "${cyan}Building base proxy image, if necessary...${no_color}"
+image_exists=$(docker images | grep "proxy-base-image\s*$dockerfile_sha1") || true
+
 if [ -z "$image_exists" ]; then
     echo -e "${blue}Building image${no_color}"
-    docker build -t="proxy-base-image" --force-rm $proxy_base_dir
+    docker build -t="proxy-base-image:$dockerfile_sha1" --force-rm $proxy_base_dir
 else
     echo -e "${blue}Base image already exists${no_color}"
 fi

--- a/test/package.json
+++ b/test/package.json
@@ -6,9 +6,9 @@
     "test": "mocha ./test_*.js"
   },
   "dependencies": {
-    "chai": "^2.2.0",
-    "jsonwebtoken": "^4.2.2",
-    "mocha": "^2.2.1",
-    "super-request": "0.0.8"
+    "chai": "^3.2.0",
+    "jsonwebtoken": "^5.0.5",
+    "mocha": "^2.3.2",
+    "super-request": "^0.1.0"
   }
 }


### PR DESCRIPTION
Lua, npm packages, and latest version of OpenResty in the base proxy Docker image.

While npm package updates will automatically refresh, there's currently no automatic refresh of Lua or the Docker image containing OpenResty. Since this is the first time we've really refreshed these dependencies, we need a mechanism for this.
