### PR TITLE
Update build_deps.sh

### DIFF
--- a/scripts/build_deps.sh
+++ b/scripts/build_deps.sh
@@ -23,6 +23,6 @@ load_dependency () {
     fi
 }
 
-load_dependency "lib/resty/jwt.lua" "SkyLothar" "lua-resty-jwt" "b7976481061239ae2027e02be552b900bf25321c" "3fbc737d2a1defcdf372cab5f854182afbcede6e"
+load_dependency "lib/resty/jwt.lua" "SkyLothar" "lua-resty-jwt" "612dcf581b5dd2b4168bab67d017c5e23b32bf0a" "cca4f2ea1f49d7c12aecc46eb151cdf63c26294b"
 load_dependency "lib/resty/hmac.lua" "jkeys089" "lua-resty-hmac" "67bff3fd6b7ce4f898b4c3deec7a1f6050ff9fc9" "44dffa232bdf20e9cf13fb37c23df089e4ae1ee2"
 load_dependency "lib/basexx.lua" "aiq" "basexx" "514f46ceb9a8a867135856abf60aaacfd921d9b9" "da8efedf0d96a79a041eddfe45a6438ea4edf58b"


### PR DESCRIPTION
update to version 0.1.2 of lua-resty-jwt which includes the ability to use RS256 with x.509 cert in JWT_SECRET without an x5c header in the token.
