### PR TITLE
rfc6750 compability

### DIFF
--- a/hosts/proxy/default/nginx/conf/nginx.conf
+++ b/hosts/proxy/default/nginx/conf/nginx.conf
@@ -29,6 +29,7 @@ http {
                 local jwt = require("nginx-jwt")
                 jwt.auth({
                     aud="^foo:",
+					scope="admin",
                     roles=function (val) return jwt.table_contains(val, "marketing") end
                 })
             ';

--- a/hosts/proxy/default/nginx/conf/nginx.conf
+++ b/hosts/proxy/default/nginx/conf/nginx.conf
@@ -29,7 +29,7 @@ http {
                 local jwt = require("nginx-jwt")
                 jwt.auth({
                     aud="^foo:",
-					scope="admin",
+                    scope="admin",
                     roles=function (val) return jwt.table_contains(val, "marketing") end
                 })
             ';

--- a/test/test_integration.js
+++ b/test/test_integration.js
@@ -146,7 +146,7 @@ describe('proxy', function () {
                 return request(url)
                     .get('/secure/admin')
                     .headers({'Authorization': 'Bearer ' + token})
-                    .expect(401)
+                    .expect(403)
                     .expect('WWW-Authenticate', 'Bearer error="insufficient_scope",scope=admin')
                     .end();
             });

--- a/test/test_integration.js
+++ b/test/test_integration.js
@@ -168,7 +168,7 @@ describe('proxy', function () {
             it("should return 200 when an authenticated user is also authorized by all claims", function () {
                 var token = jwt.sign(
                     // everything is good
-                    { sub: 'foo-user', aud: 'foo:bar', roles: ["sales", "marketing"] },
+                    { sub: 'foo-user', aud: 'foo:bar', roles: ["sales", "marketing"], scope: 'admin' },
                     secret);
 
                 return request(url)


### PR DESCRIPTION
Hi,
Saw https://github.com/auth0/nginx-jwt/issues/43

Support for the WWW-Authenticate response header, according to https://tools.ietf.org/html/rfc6750#section-3.1

For my user case, i need also specific implementation for scope as will be using in OAuth 2.0 framework.
e.g returning a 403, and the scopes required.
Not sure if you are liking that if , or if you want the lib to be more generic. 
