### PR TITLE
auth(): separate retrieval of bearer token from verification, so we c…

### DIFF
--- a/nginx-jwt.lua
+++ b/nginx-jwt.lua
@@ -35,7 +35,10 @@ function M.auth(claim_specs)
 
     -- require Bearer token
     local _, _, token = string.find(auth_header, "Bearer%s+(.+)")
+    return M.auth_token(token, claim_specs)
+end
 
+function M.auth_token(token, claim_specs)
     if token == nil then
         ngx.log(ngx.WARN, "Missing token")
         ngx.exit(ngx.HTTP_UNAUTHORIZED)


### PR DESCRIPTION
…an verify tokens not located in the Authorization header.
