### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ server {
             local jwt = require("nginx-jwt")
             jwt.auth({
                 aud="^foo:",
-                role=function (val) return jwt.table_contains(val, "marketing") end
+                roles=function (val) return jwt.table_contains(val, "marketing") end
             })
         ';
 


### PR DESCRIPTION
setting `role=function () .....` is giving `401` unauthorized, whereas setting it to `roles=function () ....` is working as expected.
