### PR TITLE
Return the JWT token from the auth func

### DIFF
--- a/nginx-jwt.lua
+++ b/nginx-jwt.lua
@@ -112,6 +112,7 @@ function M.auth(claim_specs)
 
     -- write the X-Auth-UserId header
     ngx.header["X-Auth-UserId"] = jwt_obj.payload.sub
+    return jwt_obj.payload
 end
 
 function M.table_contains(table, item)


### PR DESCRIPTION
The auth function doesn't return the decoded jwt token.
The token content can be useful in some cases, for instance: [nginx-auth](https://github.com/odedlaz/nginx-auth)
