### PR TITLE
Change JWT log level to DEBUG

### DIFF
--- a/nginx-jwt.lua
+++ b/nginx-jwt.lua
@@ -50,7 +50,7 @@ function M.auth(claim_specs)
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
 
-    ngx.log(ngx.INFO, "JWT: " .. cjson.encode(jwt_obj))
+    ngx.log(ngx.DEBUG, "JWT: " .. cjson.encode(jwt_obj))
 
     -- optionally require specific claims
     if claim_specs ~= nil then


### PR DESCRIPTION
The token might contain secret data that shouldn't be logged in production servers.
I believe the decrypted token should only be logged to DEBUG, and not INFO.
