### PR TITLE
Return jwt_obj info to caller

### DIFF
--- a/nginx-jwt.lua
+++ b/nginx-jwt.lua
@@ -112,6 +112,8 @@ function M.auth(claim_specs)
 
     -- write the X-Auth-UserId header
     ngx.header["X-Auth-UserId"] = jwt_obj.payload.sub
+    jwt_obj.token = token;
+    return jwt_obj;
 end
 
 function M.table_contains(table, item)


### PR DESCRIPTION
Sometimes you need to go a little further than a public library.

The call should be able to get the jwt_obj that is internal.

This library already parses the jwt_token out, so I expose it here as well as jwt_obj.token.
