### PR TITLE
add the option of specify the token in a COOKIE or in a request param

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 * Secure an existing HTTP service (ex: REST API) using Nginx reverse-proxy and this script
 * Authenticate an HTTP request with the verified identity contained with in a JWT
 * Optionally, authorize the same request using helper functions for asserting required JWT claims
+* Optionally, specify if the token is in the request param (bearer param) or in a cookie (bearer cookie).
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -49,12 +49,22 @@ Install steps:
 
     env JWT_SECRET;
     ```
-1. If your JWT secret is Base64 (URL-safe) encoded, export the `JWT_SECRET_IS_BASE64_ENCODED` environment variable on the Nginx host, setting it equal to `true`.  Then expose it to Nginx server:  
+2. If your JWT secret is Base64 (URL-safe) encoded, export the `JWT_SECRET_IS_BASE64_ENCODED` environment variable on the Nginx host, setting it equal to `true`.  Then expose it to Nginx server:  
     ```lua
     # nginx.conf:
 
     env JWT_SECRET_IS_BASE64_ENCODED;
     ```
+
+3. If you want specify where this script should looking for the token, export the `NGINX_JWT_TOKEN_SITE` environment variable on the Nginx host, setting it equal to `HEADER`, `COOKIE` , `REQUEST`.  Then expose it to Nginx server:  
+    ```lua
+    # nginx.conf:
+
+    env NGINX_JWT_TOKEN_SITE;
+    ```
+ In case that you choose COOKIE or HEADER, this script try to found a "bearer" cookie or request parameter.   
+
+
 
 ## Usage
 


### PR DESCRIPTION
add the option of specify the token in a COOKIE or in a request param, with a new optionally enviroment variable, you can choose where the token is provided. the cookie or the request param must be called "bearer".